### PR TITLE
Upgrade to support newer versions of ESX

### DIFF
--- a/Kuzkay_Meth/__resource.lua
+++ b/Kuzkay_Meth/__resource.lua
@@ -1,2 +1,0 @@
-client_script "client.lua"
-server_script "server.lua"

--- a/Kuzkay_Meth/client.lua
+++ b/Kuzkay_Meth/client.lua
@@ -1,3 +1,5 @@
+ESX = exports["es_extended"]:getSharedObject()
+
 local Keys = {
 	["ESC"] = 322, ["F1"] = 288, ["F2"] = 289, ["F3"] = 170, ["F5"] = 166, ["F6"] = 167, ["F7"] = 168, ["F8"] = 169, ["F9"] = 56, ["F10"] = 57,
 	["~"] = 243, ["1"] = 157, ["2"] = 158, ["3"] = 160, ["4"] = 164, ["5"] = 165, ["6"] = 159, ["7"] = 161, ["8"] = 162, ["9"] = 163, ["-"] = 84, ["="] = 83, ["BACKSPACE"] = 177,
@@ -16,7 +18,6 @@ local CurrentVehicle
 local pause = false
 local selection = 0
 local quality = 0
-ESX = nil
 
 local LastCar
 
@@ -25,12 +26,6 @@ function DisplayHelpText(str)
 	AddTextComponentString(str)
 	DisplayHelpTextFromStringLabel(0, 0, 1, -1)
 end
-Citizen.CreateThread(function()
-	while ESX == nil do
-		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-		Citizen.Wait(0)
-	end
-end)
 
 RegisterNetEvent('esx_methcar:stop')
 AddEventHandler('esx_methcar:stop', function()

--- a/Kuzkay_Meth/fxmanifest.lua
+++ b/Kuzkay_Meth/fxmanifest.lua
@@ -1,0 +1,5 @@
+fx_version 'adamant'
+game 'gta5'
+
+client_script 'client.lua'
+server_script 'server.lua'

--- a/Kuzkay_Meth/server.lua
+++ b/Kuzkay_Meth/server.lua
@@ -2,8 +2,6 @@ ESX = exports["es_extended"]:getSharedObject()
 
 print("Meth car got loaded, Made by Kuzkay")
 
-TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-
 RegisterServerEvent('esx_methcar:start')
 AddEventHandler('esx_methcar:start', function()
 	local _source = source

--- a/Kuzkay_Meth/server.lua
+++ b/Kuzkay_Meth/server.lua
@@ -1,6 +1,7 @@
+ESX = exports["es_extended"]:getSharedObject()
+
 print("Meth car got loaded, Made by Kuzkay")
-	
-ESX = nil
+
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
 RegisterServerEvent('esx_methcar:start')


### PR DESCRIPTION
Updated es_extended support by removing the deprecated esx:getSharedObject event and using the export from es_extended. Also updated the resource manifest from __resource.lua to fxmanifest.lua as the former is no longer supported.